### PR TITLE
wording changes in Description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.1.0
 Depends: R (>= 2.10)
 Author: Hyowon An
 Maintainer: Hyowon An <ahwbest@gmail.com>
-Description: dr4pl models the relationship between dose levels and responses in a pharmacological experiment using the 4 Parameter Logistic model. dr4pl currently only supports decreasing curves. To deal with a convergence failure problem of nonlinear regression models, this package supports features to detect convergence failure and presents some solutions to a user.
+Description: Models the relationship between dose levels and responses in a pharmacological experiment using the 4 Parameter Logistic model. Currently only decreasing curves are supported. To deal with a convergence failure problem of nonlinear regression models, methods are provided to detect convergence failure as well as suggested solutions.
 License: GPL
 LazyData: TRUE
 URL: https://github.com/ahwbest/dr4pl


### PR DESCRIPTION
CRAN checker dislikes descriptions that mention the package name.
Made small wording changes.